### PR TITLE
[Bug 8856] Support high-resolution images

### DIFF
--- a/framework/source/class/qx/ui/basic/Image.js
+++ b/framework/source/class/qx/ui/basic/Image.js
@@ -174,6 +174,10 @@ qx.Class.define("qx.ui.basic.Image",
   },
 
 
+  statics:
+  {
+    PLACEHOLDER_IMAGE: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+  },
 
   /*
   *****************************************************************************
@@ -743,9 +747,13 @@ qx.Class.define("qx.ui.basic.Image",
      * @param source {String} source path
      */
     __setSource : function(el, source) {
-      if (el.getNodeName() == "div") {
+      var highResSource = (source && qx.util.ResourceManager.getInstance().has(source)) ?
+          this._findHighResolutionSource(source) : null;
 
-        var dec = qx.theme.manager.Decoration.getInstance().resolve(this.getDecorator());
+      var dec = qx.theme.manager.Decoration.getInstance().resolve(this.getDecorator());
+
+      if (el.getNodeName() == "div" || highResSource && dec) {
+
         // if the decorator defines any CSS background-image
         if (dec) {
           var hasGradient = (dec.getStartColor() && dec.getEndColor());
@@ -754,7 +762,7 @@ qx.Class.define("qx.ui.basic.Image",
             var repeat = this.getScale() ? "scale" : "no-repeat";
 
             // get the style attributes for the given source
-            var attr = qx.bom.element.Decoration.getAttributes(source, repeat);
+            var attr = qx.bom.element.Decoration.getAttributes(highResSource || source, repeat);
             // get the background image(s) defined by the decorator
             var decStyle = dec.getStyles(true);
 
@@ -763,6 +771,12 @@ qx.Class.define("qx.ui.basic.Image",
               "backgroundPosition": (attr.style.backgroundPosition || "0 0"),
               "backgroundRepeat": (attr.style.backgroundRepeat || "no-repeat")
             };
+            if(highResSource)
+            {
+              combinedStyles.backgroundSize = "100%, auto";
+              combinedStyles.backgroundRepeat = "no-repeat";
+              combinedStyles.backgroundPosition = "50% 50%";
+            }
 
             if (hasBackground) {
               combinedStyles["backgroundPosition"] += "," + decStyle["background-position"] || "0 0";
@@ -779,6 +793,9 @@ qx.Class.define("qx.ui.basic.Image",
             // apply combined background images
             el.setStyles(combinedStyles);
 
+            if(el.getNodeName() == "img")
+              el.setAttribute("src", qx.ui.basic.Image.PLACEHOLDER_IMAGE);
+
             return;
           }
         } else {
@@ -787,9 +804,97 @@ qx.Class.define("qx.ui.basic.Image",
         }
       }
 
-      el.setSource(source);
+      if(highResSource)
+        this._createHighResolutionOverlay(highResSource);
+      else
+        el.setSource(source);
     },
 
+    /**
+     * Detects whether there is a high-resolution image available.
+     * A high-resolution image is assumed to have the same file name as
+     * the parameter source, but with a pixelRatio identifier before the file
+     * extension, like "@2x".
+     * Medium Resolution: "example.png", high-resolution: "example@2x.png"
+     *
+     * @param lowResImgSrc {String} source of the low resolution image.
+     * @return {String} If a high-resolution image source.
+     */
+    _findHighResolutionSource: function(lowResImgSrc) {
+      var pixelRatioCandidates = ["3", "2", "1.5"];
+
+      // Calculate the optimal ratio, based on the rem scale factor of the application and the device pixel ratio.
+      var factor = parseFloat(qx.bom.client.Device.getDevicePixelRatio().toFixed(2));
+      if (factor <= 1) {
+        return false;
+      }
+
+      var i = pixelRatioCandidates.length;
+      while (i > 0 && factor > pixelRatioCandidates[--i]) {}
+
+      var hiResImgSrc;
+
+      // Search for best img with a higher resolution.
+      for (var k = i; k >= 0; k--) {
+        hiResImgSrc = this._getHighResolutionSource(lowResImgSrc, pixelRatioCandidates[k]);
+        if (hiResImgSrc) {
+          return hiResImgSrc;
+        }
+      }
+
+      // Search for best img with a lower resolution.
+      for (var k = i + 1; k < pixelRatioCandidates.length; k++) {
+        hiResImgSrc = this._getHighResolutionSource(lowResImgSrc, pixelRatioCandidates[k]);
+        if (hiResImgSrc) {
+          return hiResImgSrc;
+        }
+      }
+
+      return null;
+    },
+
+    /**
+     * Returns the source name for the high-resolution image based on the passed
+     * parameters.
+     * @param source {String} the source of the medium resolution image.
+     * @param pixelRatio {Number} the pixel ratio of the high-resolution image.
+     * @return {String} the high-resolution source name or null if no source could be found.
+     */
+    _getHighResolutionSource : function(source, pixelRatio) {
+      var fileExtIndex = source.lastIndexOf('.');
+      if (fileExtIndex > -1) {
+        var pixelRatioIdentifier = "@" + pixelRatio + "x";
+        var candidate = source.slice(0, fileExtIndex) + pixelRatioIdentifier + source.slice(fileExtIndex);
+
+        if(qx.util.ResourceManager.getInstance().has(candidate)) {
+          return candidate;
+        }
+      }
+      return null;
+    },
+
+
+    /**
+     * Creates an overlay for this image which shows the image defined by the parameter 'highResSource',
+     * but has the same size and position as the source image.
+     * The original image widget is hidden by this method.
+     *
+     * @param highResSource {String} Image source of the high-resolution image.
+     * @param lowResSource {String} Image source of the low-resolution image.
+     */
+    _createHighResolutionOverlay : function(highResSource, lowResSource) {
+      // Replace the source through transparent pixel for making the high-resolution background image visible.
+      var el = this.getContentElement();
+      el.setAttribute("src", qx.ui.basic.Image.PLACEHOLDER_IMAGE);
+      var resourceManager = qx.util.ResourceManager.getInstance();
+      el.setStyles({
+        backgroundImage: "url("+resourceManager.toUri(highResSource)+")",
+        backgroundSize: "100%",
+        backgroundRepeat: "no-repeat",
+        backgroundPosition: "50% 50%",
+        position: "absolute"
+      });
+    },
 
     /**
      * Event handler fired after the preloader has finished loading the icon


### PR DESCRIPTION
Qooxdoo Mobile JsDoc: 
"A high-resolution image is assumed to have the same file name as the parameter
source, but with a pixelRatio identifier before the file extension, like "@2x".
Medium Resolution: "example.png", high-resolution: "example@2x.png"

So, we have it for qooxdoo mobile, but not for desktop. It would be nice to
have high-resolution images everywhere.
